### PR TITLE
Add support for Mixin 0.8.4+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,6 +156,14 @@ java {
     withSourcesJar()
 }
 
+processResources {
+    duplicatesStrategy(DuplicatesStrategy.INCLUDE)
+    from (sourceSets.main.resources.srcDirs) {
+        include("mcmod.info")
+        expand("version": version)
+    }
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,9 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 buildscript {
     repositories {
-        maven { url = 'https://maven.minecraftforge.net' }
+        maven { url 'https://maven.minecraftforge.net' }
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url "https://repo.spongepowered.org/repository/maven-public" }
-        jcenter()
         mavenCentral()
     }
     dependencies {
@@ -47,7 +46,7 @@ minecraft {
         client {
 
             jvmArg "-Dfml.coreMods.load=org.dimdev.jeid.JEIDLoadingPlugin"
-                    jvmArg "-Dmixin.hotSwap=true"
+            jvmArg "-Dmixin.hotSwap=true"
             jvmArg "-Dmixin.checks.interfaces=true"
 
             workingDirectory project.file('run')
@@ -62,7 +61,7 @@ minecraft {
         server {
 
             jvmArg "-Dfml.coreMods.load=org.dimdev.jeid.JEIDLoadingPlugin"
-                    jvmArg "-Dmixin.hotSwap=true"
+            jvmArg "-Dmixin.hotSwap=true"
             jvmArg "-Dmixin.checks.interfaces=true"
 
             // Recommended logging data for a userdev environment
@@ -81,27 +80,14 @@ configurations {
 }
 
 repositories {
-    maven { url = "https://dvs1.progwml6.com/files/maven" }
-    maven { url = "https://minecraft.curseforge.com/api/maven" }
-    maven { url "https://maven.tterrag.com" }
-    maven { url "https://maven.blamejared.com" }
-    maven { url "https://maven.mcmoddev.com/" }
     maven { url "https://repo.spongepowered.org/maven" }
-    maven {
-        name = "buildcraft"
-        url = "https://mod-buildcraft.com/maven"
-    }
-    maven {
-        name = "thiakil"
-        url = "https://maven.thiakil.com"
-    }
-    maven {
-        url = "https://dvs1.progwml6.com/files/maven"
-    }
     maven {
         url "https://cursemaven.com"
         content {
             includeGroup "curse.maven"
+        }
+        metadataSources {
+            artifact()
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.github.jengelman.gradle.plugins:shadow:2.0.4"
-        classpath 'net.minecraftforge.gradle:ForgeGradle:5.0.+'
+        classpath "gradle.plugin.com.github.johnrengelman:shadow:7.1.1"
+        classpath 'net.minecraftforge.gradle:ForgeGradle:5.1.+'
         classpath "org.spongepowered:mixingradle:0.7-SNAPSHOT"
     }
 }
@@ -105,7 +105,7 @@ dependencies {
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
     minecraft 'net.minecraftforge:forge:1.12.2-14.23.5.2860'
 
-    implementation("org.spongepowered:mixin:0.8.5") {
+    implementation("org.spongepowered:mixin:0.8.3") {
         exclude module: "asm-commons"
         exclude module: "asm-tree"
         exclude module: "launchwrapper"

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,4 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 buildscript {
     repositories {
@@ -73,6 +74,12 @@ minecraft {
     }
 }
 
+configurations {
+    compileJar {
+        implementation.extendsFrom(compileJar)
+    }
+}
+
 repositories {
     maven { url = "https://dvs1.progwml6.com/files/maven" }
     maven { url = "https://minecraft.curseforge.com/api/maven" }
@@ -105,7 +112,8 @@ dependencies {
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
     minecraft 'net.minecraftforge:forge:1.12.2-14.23.5.2860'
 
-    implementation("org.spongepowered:mixin:0.8.3") {
+    annotationProcessor("org.spongepowered:mixin:0.8.3:processor")
+    compileJar("org.spongepowered:mixin:0.8.3") {
         exclude module: "asm-commons"
         exclude module: "asm-tree"
         exclude module: "launchwrapper"
@@ -158,6 +166,10 @@ jar.finalizedBy('reobfJar')
 // However if you are in a multi-project build, dev time needs unobfed jar files, so you can delay the obfuscation until publishing by doing
 //publish.dependsOn('reobfJar')
 
+java {
+    withSourcesJar()
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {
@@ -178,22 +190,33 @@ mixin {
 }
 
 shadowJar {
-    classifier ""
-    exclude "LICENSE.txt", "dummyThing"
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    archiveClassifier.set(null)
+    configurations = [project.configurations.compileJar]
 }
 
+task thinShadowJar(type: ShadowJar) {
+    archiveClassifier.set("thin")
+    configurations = [project.configurations.compileJar]
+    relocators = shadowJar.relocators
 
+    dependencies {
+        exclude(dependency("org.spongepowered:mixin"))
+    }
 
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier "sources"
-    from sourceSets.main.allSource
+    manifest {
+        inheritFrom jar.manifest
+    }
+
+    from sourceSets.main.output
 }
 
 artifacts {
-    archives jar
     archives shadowJar
     archives sourcesJar
+    archives thinShadowJar
 }
 
+reobf {
+    shadowJar {}
+    thinShadowJar {}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-import wtf.gofancy.fancygradle.patch.Patch
 
 buildscript {
     repositories {
@@ -7,16 +6,11 @@ buildscript {
         maven { url "https://repo.spongepowered.org/repository/maven-public" }
         jcenter()
         mavenCentral()
-        maven {
-            name 'FancyGradle'
-            url 'https://gitlab.com/api/v4/projects/26758973/packages/maven'
-        }
     }
     dependencies {
         classpath "com.github.jengelman.gradle.plugins:shadow:2.0.4"
         classpath 'net.minecraftforge.gradle:ForgeGradle:5.0.+'
         classpath "org.spongepowered:mixingradle:0.7-SNAPSHOT"
-        classpath group: 'wtf.gofancy.fancygradle', name: 'wtf.gofancy.fancygradle.gradle.plugin', version: '1.1.+'
     }
 }
 
@@ -24,7 +18,6 @@ apply plugin: 'net.minecraftforge.gradle'
 // Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
-apply plugin: 'wtf.gofancy.fancygradle'
 apply plugin: "com.github.johnrengelman.shadow"
 apply plugin: 'org.spongepowered.mixin'
 
@@ -203,10 +196,4 @@ artifacts {
     archives sourcesJar
 }
 
-fancyGradle {
-    patches {
-        resources
-        coremods
-        asm
-    }
 }

--- a/src/main/java/org/dimdev/jeid/mixin/init/JEIDMixinLoader.java
+++ b/src/main/java/org/dimdev/jeid/mixin/init/JEIDMixinLoader.java
@@ -1,6 +1,5 @@
 package org.dimdev.jeid.mixin.init;
 
-import net.minecraft.launchwrapper.Launch;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.ModClassLoader;
 import net.minecraftforge.fml.common.ModContainer;
@@ -11,7 +10,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.transformer.Proxy;
+import org.spongepowered.asm.mixin.transformer.ext.Extensions;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -43,31 +42,51 @@ public class JEIDMixinLoader {
         Mixins.addConfiguration("mixins.jeid.modsupport.json");
         Mixins.addConfiguration("mixins.jeid.twilightforest.json");
 
-        Proxy mixinProxy = (Proxy) Launch.classLoader.getTransformers().stream().filter(transformer -> transformer instanceof Proxy).findFirst().get();
         try {
-            //This will very likely break on the next major mixin release.
-            Class mixinTransformerClass = Class.forName("org.spongepowered.asm.mixin.transformer.MixinTransformer");
-
-            Field transformerField = Proxy.class.getDeclaredField("transformer");
+            // This will very likely break on the next major mixin release.
+            Class<?> proxyClass = Class.forName("org.spongepowered.asm.mixin.transformer.Proxy");
+            Field transformerField = proxyClass.getDeclaredField("transformer");
             transformerField.setAccessible(true);
-            Object transformer = transformerField.get(mixinProxy);
-
-            //Get MixinProcessor from MixinTransformer
+            Object transformer = transformerField.get(null);
+            
+            Class<?> mixinTransformerClass = Class.forName("org.spongepowered.asm.mixin.transformer.MixinTransformer");
             Field processorField = mixinTransformerClass.getDeclaredField("processor");
             processorField.setAccessible(true);
             Object processor = processorField.get(transformer);
-
+            
             Class<?> mixinProcessorClass = Class.forName("org.spongepowered.asm.mixin.transformer.MixinProcessor");
-
+            
+            Field extensionsField = mixinProcessorClass.getDeclaredField("extensions");
+            extensionsField.setAccessible(true);
+            Object extensions = extensionsField.get(processor);
+            
             Method selectConfigsMethod = mixinProcessorClass.getDeclaredMethod("selectConfigs", MixinEnvironment.class);
             selectConfigsMethod.setAccessible(true);
             selectConfigsMethod.invoke(processor, MixinEnvironment.getCurrentEnvironment());
-
-            Method prepareConfigsMethod = mixinProcessorClass.getDeclaredMethod("prepareConfigs", MixinEnvironment.class);
-            prepareConfigsMethod.setAccessible(true);
-            prepareConfigsMethod.invoke(processor, MixinEnvironment.getCurrentEnvironment());
-        } catch (ReflectiveOperationException e) {
-            throw new RuntimeException(e);
+            
+            // Mixin 0.8.4+
+            try {
+                Method prepareConfigs = mixinProcessorClass.getDeclaredMethod("prepareConfigs", MixinEnvironment.class, Extensions.class);
+                prepareConfigs.setAccessible(true);
+                prepareConfigs.invoke(processor, MixinEnvironment.getCurrentEnvironment(), extensions);
+                return;
+            } catch (NoSuchMethodException ex) {
+                // no-op
+            }
+            
+            // Mixin 0.8+
+            try {
+                Method prepareConfigs = mixinProcessorClass.getDeclaredMethod("prepareConfigs", MixinEnvironment.class);
+                prepareConfigs.setAccessible(true);
+                prepareConfigs.invoke(processor, MixinEnvironment.getCurrentEnvironment());
+                return;
+            } catch (NoSuchMethodException ex) {
+                // no-op
+            }
+            
+            throw new UnsupportedOperationException("Unsupported Mixin");
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
         }
     }
 }

--- a/src/main/java/org/dimdev/jeid/mixin/init/JEIDMixinLoader.java
+++ b/src/main/java/org/dimdev/jeid/mixin/init/JEIDMixinLoader.java
@@ -11,7 +11,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.transformer.MixinProcessor;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -58,11 +57,13 @@ public class JEIDMixinLoader {
             processorField.setAccessible(true);
             Object processor = processorField.get(transformer);
 
-            Method selectConfigsMethod = MixinProcessor.class.getDeclaredMethod("selectConfigs", MixinEnvironment.class);
+            Class<?> mixinProcessorClass = Class.forName("org.spongepowered.asm.mixin.transformer.MixinProcessor");
+
+            Method selectConfigsMethod = mixinProcessorClass.getDeclaredMethod("selectConfigs", MixinEnvironment.class);
             selectConfigsMethod.setAccessible(true);
             selectConfigsMethod.invoke(processor, MixinEnvironment.getCurrentEnvironment());
 
-            Method prepareConfigsMethod = MixinProcessor.class.getDeclaredMethod("prepareConfigs", MixinEnvironment.class);
+            Method prepareConfigsMethod = mixinProcessorClass.getDeclaredMethod("prepareConfigs", MixinEnvironment.class);
             prepareConfigsMethod.setAccessible(true);
             prepareConfigsMethod.invoke(processor, MixinEnvironment.getCurrentEnvironment());
         } catch (ReflectiveOperationException e) {

--- a/src/main/java/org/dimdev/jeid/mixin/init/JEIDMixinLoader.java
+++ b/src/main/java/org/dimdev/jeid/mixin/init/JEIDMixinLoader.java
@@ -11,10 +11,10 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.transformer.Proxy;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
 import java.net.MalformedURLException;
 import java.util.List;
 

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -6,7 +6,7 @@
       "name": "JustEnoughIDs",
       "description": "Use the 1.13 chunk format in 1.12 to remove block, item, and biome ID limits.\n\nThanks to zabi94 for helping getting potions and enchants extended.",
       "version": "${version}",
-      "mcversion": "${mcversion}",
+      "mcversion": "1.12.2",
       "url": "https://minecraft.curseforge.com/projects/jeid",
       "authorList": [
         "Runemoro",


### PR DESCRIPTION
This PR adds support for Mixin 0.8.4+ and makes changes to the build.gradle to improve the build.

The following jars are created:
1. JustEnoughIDs-x.x.x.jar - Includes Mixin 0.8.3 (Mixin 0.8.4+ will not work on 1.12.2)
2. JustEnoughIDs-x.x.x-**thin**.jar - Excludes Mixin (For resolving Mixin version conflicts)

Fixes https://github.com/LXGaming/MixinBootstrap/issues/51
Fixes https://github.com/DimensionalDevelopment/JustEnoughIDs/issues/184